### PR TITLE
Fixed Class name of GoogleMoviesClientEvents

### DIFF
--- a/src/GoogleMoviesClient/Events/GoogleMoviesClientEvents.php
+++ b/src/GoogleMoviesClient/Events/GoogleMoviesClientEvents.php
@@ -13,7 +13,7 @@
  */
 namespace GoogleMoviesClient\Events;
 
-final class GoogleMovieClientEvents
+final class GoogleMoviesClientEvents
 {
     /** Request */
     const BEFORE_REQUEST = 'gmc.before_request';


### PR DESCRIPTION
Fix a big due to the last style improvements renamed a class based on its filename which was wrong.
