### PR TITLE
Make use of unused 'secure' option to toggle use of SSL

### DIFF
--- a/src/GoogleMoviesClient/Client.php
+++ b/src/GoogleMoviesClient/Client.php
@@ -487,8 +487,8 @@ class Client implements ClientInterface
     protected function postResolve(array $options = [])
     {
         $this->options['base_url'] = sprintf(
-            '%s://%s',
-            'https',
+            'http%s://%s',
+            $this->options['secure'] ? 's' : '',
             $this->options['host']
         );
         if (! $this->options['adapter']) {


### PR DESCRIPTION
The `$options['secure']` variable in the Client appears to be unused so code has been added to toggle use of SSL in the set up of the base URL. This allows the user to prevent circumvent SSL errors, such as "cURL error 60: SSL certificate problem: unable to get local issuer certificate", which I was receiving.
